### PR TITLE
Add a change() method to the state machine

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -42,7 +42,7 @@ export fn start() void {
     menustate = mainmenu.Menu.init();
     parliament = houseofcommons.Parliament.init(&rnd);
 
-    state.screen = .AT_HOUSE_OF_COMMONS;
+    state.change(.AT_HOUSE_OF_COMMONS);
 }
 
 export fn update() void {
@@ -55,7 +55,7 @@ export fn update() void {
         .ROUND_DONE => {
             // tally score
             // reset state and go again
-            state.screen = .AT_PARTY;
+            state.change(.AT_PARTY);
         },
         else => {},
     }

--- a/src/screens/house-of-commons.zig
+++ b/src/screens/house-of-commons.zig
@@ -101,7 +101,7 @@ pub const Parliament = struct {
             // reset states
             self.reset();
             // go back to the party
-            state.screen = .ROUND_DONE;
+            state.change(.ROUND_DONE);
         }
     }
 

--- a/src/screens/party.zig
+++ b/src/screens/party.zig
@@ -91,7 +91,7 @@ pub const PartyState = struct {
             if (self.round >= 3) {
                 // reset self
                 self.reset();
-                state.screen = .AT_PRESS_CONFERENCE;
+                state.change(.AT_PRESS_CONFERENCE);
             } else {
                 // new situation
                 self.setRandomSituation();

--- a/src/screens/press-conference.zig
+++ b/src/screens/press-conference.zig
@@ -89,7 +89,7 @@ pub const PressState = struct {
             if (self.round >= 3) {
                 // reset self
                 self.reset();
-                state.screen = .AT_HOUSE_OF_COMMONS;
+                state.change(.AT_HOUSE_OF_COMMONS);
             } else {
                 // new situation
                 self.setRandomSituation();

--- a/src/screens/start-screen.zig
+++ b/src/screens/start-screen.zig
@@ -6,7 +6,7 @@ const statemachine = @import("../state-machine.zig");
 var start_ticks: u32 = 0;
 pub fn handleInput(state: *statemachine.StateMachine, pl: *const gamepad.GamePad) void {
     if (pl.isPressed(w4.BUTTON_DOWN) or pl.isPressed(w4.BUTTON_UP) or pl.isPressed(w4.BUTTON_LEFT) or pl.isPressed(w4.BUTTON_RIGHT) or pl.isPressed(w4.BUTTON_1) or pl.isPressed(w4.BUTTON_2)) {
-        state.screen = .AT_PARTY;
+        state.change(.AT_PARTY);
     }
 }
 

--- a/src/state-machine.zig
+++ b/src/state-machine.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 pub const Screens = enum { IN_MENU, AT_PARTY, AT_PRESS_CONFERENCE, AT_HOUSE_OF_COMMONS, SUE_GRAY, PAUSED_SCREEN, START_SCREEN, ROUND_DONE };
 
 pub const StateMachine = struct {
-    screen: Screens = .IN_MENU,
+    screen: Screens = undefined,
 
     // player state
     buzzing: u32 = 0,
@@ -13,12 +13,16 @@ pub const StateMachine = struct {
 
     // screen states
 
+    pub fn change(self: *@This(), state: Screens) void {
+        self.screen = state;
+    }
+
     pub fn reset(self: *@This()) void {
         self.buzzing = 0;
         self.confidence = 0;
         self.totalscore = 0;
 
-        self.screen = .IN_MENU;
+        self.change(.IN_MENU);
     }
 
     pub fn init() StateMachine {


### PR DESCRIPTION
No more setting the state directly. This gives us the opportunity to hook into state changes and do something more when they happen.